### PR TITLE
Added support for iPad 5 (2017)

### DIFF
--- a/json/deviceModels.json
+++ b/json/deviceModels.json
@@ -62,7 +62,9 @@
         "iPad6,3",
         "iPad6,4",
         "iPad6,7",
-        "iPad6,8"
+        "iPad6,8",
+        "iPad6,11",
+        "iPad6,12"
     ],
     "AppleTV": [
         "AppleTV2,1",

--- a/json/devices.json
+++ b/json/devices.json
@@ -30,6 +30,8 @@
     "iPad6,8",
     "iPad6,3",
     "iPad6,4",
+    "iPad6,11",
+    "iPad6,12",
     "iPhone1,1",
     "iPhone1,2",
     "iPhone2,1",

--- a/json/iPad.json
+++ b/json/iPad.json
@@ -29,5 +29,7 @@
     "iPad Pro 9.7-inch (WiFi)",
     "iPad Pro 9.7-inch (Cellular)",
     "iPad Pro 12.9-inch (WiFi)",
-    "iPad Pro 12.9-inch (Cellular)"
+    "iPad Pro 12.9-inch (Cellular)",
+    "iPad 5 (WiFi)",
+    "iPad 5 (Cellular)"
 ]


### PR DESCRIPTION
iPad 5 (both wifi and cellular) can now be selected using the dropdown menu so users can save blobs for it.